### PR TITLE
Allow whitelisting some email domains so they may send DMs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,6 +28,13 @@
                 "type": "text",
                 "help_text": "Enter the message to display to users who try to send a direct message.",
                 "default": "Direct messages have been disabled by an administrator."
+            },
+            {
+                "key": "AllowedDomains",
+                "display_name": "Allowed Email Domains",
+                "type": "longtext",
+                "help_text": "Users with one of the domains (one per line) in this field never get their messages rejected.",
+                "default": ""
             }
         ],
         "header": "",

--- a/server/config/main.go
+++ b/server/config/main.go
@@ -21,6 +21,7 @@ type Configuration struct {
 	RejectDMs        bool   `json:"RejectDMs"`
 	RejectGroupChats bool   `json:"RejectGroupChats"`
 	RejectionMessage string `json:"RejectionMessage"`
+	AllowedDomains   string `json:"AllowedDomains"`
 }
 
 func GetConfig() *Configuration {


### PR DESCRIPTION
This PR allows specifying a list of email domains that are still allowed to send DMs if their email is on a specific domain.

This helped us reach some of the requirements needed in a large(ish) edu installation.

I'm opening this PR to elicit some feedback on the implementation. Would you be interested in adding such a feature to the disable-dm plugin? I'm sure the implementation needs some cleanup which I would take care of should you be interested in landing the feature.